### PR TITLE
自動更新の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -80,8 +80,7 @@ $(function() {
     // 指定したグループページのURLと一致した場合のみ
     if(location.href.match(/\/groups\/\d+\/messages/)){
       //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
-      last_message_id = $('.messages .message:first').data('message-id');
-      console.log('last_message_id:' + last_message_id);
+      last_message_id = $('.messages .message:last').data('message-id');
       $.ajax({
         // 接続先        : /groups/id番号/api/messages
         // httpメソッド   : get
@@ -93,9 +92,6 @@ $(function() {
       })
 
       .done(function(messages) {
-        console.log('success');
-        console.log('message[0]:' + JSON.stringify(messages[0]));
-
         //追加するHTMLの入れ物を作る
         var insertHTML = '';
 
@@ -111,7 +107,8 @@ $(function() {
       })
 
       .fail(function() {
-        console.log('error');
+        // アラートメッセージを表示する
+        alert('自動更新に失敗しました')
       });
   }
   };

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -73,18 +73,12 @@ $(function() {
     })
   })
 
-  //###################
-  // メッセージの自動更新
-  //###################
   var reloadMessages = function() {
     // 指定したグループページのURLと一致した場合のみ
     if(location.href.match(/\/groups\/\d+\/messages/)){
       //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
       last_message_id = $('.messages .message:last').data('message-id');
       $.ajax({
-        // 接続先        : /groups/id番号/api/messages
-        // httpメソッド   : get
-        // dataオプション : 最新のmessage_id
         url: 'api/messages',
         type: 'get',
         dataType: 'json',

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,7 +1,7 @@
 $(function() {
   // 取得したデータを元にmessage部分のhtmlを生成する
   function buildHTML(message){
-      var html = `<div class="message">
+      var html = `<div class="message" data-message-id="${ message.id }">
                     <div class="message__upper-info">
                       <p class="message__upper-info__talker">
                         ${ message.user_name }
@@ -72,4 +72,50 @@ $(function() {
       $('.submit-btn').prop('disabled', false);
     })
   })
+
+  //###################
+  // メッセージの自動更新
+  //###################
+  var reloadMessages = function() {
+    // 指定したグループページのURLと一致した場合のみ
+    if(location.href.match(/\/groups\/\d+\/messages/)){
+      //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
+      last_message_id = $('.messages .message:first').data('message-id');
+      console.log('last_message_id:' + last_message_id);
+      $.ajax({
+        // 接続先        : /groups/id番号/api/messages
+        // httpメソッド   : get
+        // dataオプション : 最新のmessage_id
+        url: 'api/messages',
+        type: 'get',
+        dataType: 'json',
+        data: {id: last_message_id}
+      })
+
+      .done(function(messages) {
+        console.log('success');
+        console.log('message[0]:' + JSON.stringify(messages[0]));
+
+        //追加するHTMLの入れ物を作る
+        var insertHTML = '';
+
+        //メッセージの数だけmessageのHTMLを生成
+        messages.forEach(function(message){
+          insertHTML = buildHTML(message)
+        });
+        //メッセージを追加
+        $('.messages').append(insertHTML);
+
+        // スクロールの処理を実行する
+        scroll()
+      })
+
+      .fail(function() {
+        console.log('error');
+      });
+  }
+  };
+
+    // 5秒毎にメッセージの自動更新を実行する
+    setInterval(reloadMessages, 5000);
 })

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,10 @@
+class Api::MessagesController < ApplicationController
+  def index
+    # ルーティングでの設定によりparamsの中にgroup_idというキーでグループのidが入るので、これを元にDBからグループを取得する
+    group = Group.find(params[:group_id])
+    # ajaxで送られてくる最後のメッセージのid番号を変数に代入
+    last_message_id = params[:id].to_i
+    # 取得したグループでのメッセージ達から、idがlast_messge_idよりも新しい(大きい)メッセージ達のみを取得
+    @messages = group.messages.includes(:user).where("id > #{last_message_id}")
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.text message.text
+  json.image message.image
+  json.created_at message.created_at
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,7 +1,7 @@
 json.array! @messages do |message|
   json.text message.text
-  json.image message.image
-  json.created_at message.created_at
+  json.image message.image.url
+  json.time message.created_at.strftime("%Y/%m/%d %H:%M")
   json.user_name message.user.name
   json.id message.id
 end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{data: {id: message.id}}
   .message__upper-info
     %p.message__upper-info__talker
       = message.user.name

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message{data: {id: message.id}}
+.message{data: {message: {id: message.id}}}
   .message__upper-info
     %p.message__upper-info__talker
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.user_name @message.user.name
 json.text @message.text
 json.time @message.created_at.strftime("%Y/%m/%d %H:%M")
 json.image @message.image.url
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,9 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,6 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
-    
     namespace :api do
       resources :messages, only: :index, defaults: { format: 'json' }
     end


### PR DESCRIPTION
## What
ChatSpaceのグループ内メッセージを自動で更新する機能を実装します。

## Why
リロードしなくても自分以外のメンバーから送られたメッセージが表示されるようになるため、最新のメッセージの取得漏れを防ぎ利用者の手間を省く事ができます。